### PR TITLE
[feat] 스텝 이동 기능 구현 및 공통 ui 적용

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,26 @@
+import { useState } from 'react';
+
+import {
+  AiConversionPage,
+  CameraPage,
+  InfoInputPage,
+  StartPage,
+  ThemeSelectPage,
+} from './pageContainer';
+import { STEP, type Step } from './types';
+
 const App = () => {
-  return <>who are you v2</>;
+  const [step, setStep] = useState<Step>(STEP.START);
+
+  return (
+    <div className="h-screen bg-[#f8f8f8]">
+      {step === STEP.START && <StartPage />}
+      {step === STEP.CAMERA && <CameraPage />}
+      {step === STEP.AI_CONVERSION && <AiConversionPage />}
+      {step === STEP.INFO_INPUT && <InfoInputPage />}
+      {step === STEP.THEME_SELECT && <ThemeSelectPage />}
+    </div>
+  );
 };
 
 export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,11 +14,11 @@ const App = () => {
 
   return (
     <div className="h-screen bg-[#f8f8f8]">
-      {step === STEP.START && <StartPage />}
-      {step === STEP.CAMERA && <CameraPage />}
-      {step === STEP.AI_CONVERSION && <AiConversionPage />}
-      {step === STEP.INFO_INPUT && <InfoInputPage />}
-      {step === STEP.THEME_SELECT && <ThemeSelectPage />}
+      {step === STEP.START && <StartPage setStep={setStep} />}
+      {step === STEP.CAMERA && <CameraPage setStep={setStep} />}
+      {step === STEP.AI_CONVERSION && <AiConversionPage setStep={setStep} />}
+      {step === STEP.INFO_INPUT && <InfoInputPage setStep={setStep} />}
+      {step === STEP.THEME_SELECT && <ThemeSelectPage setStep={setStep} />}
     </div>
   );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ const App = () => {
   const [step, setStep] = useState<Step>(STEP.START);
 
   return (
-    <div className="h-screen bg-[#f8f8f8]">
+    <div className="flex h-screen items-center justify-center bg-[#f8f8f8]">
       {step === STEP.START && <StartPage setStep={setStep} />}
       {step === STEP.CAMERA && <CameraPage setStep={setStep} />}
       {step === STEP.AI_CONVERSION && <AiConversionPage setStep={setStep} />}

--- a/src/pageContainer/AiConversionPage/index.tsx
+++ b/src/pageContainer/AiConversionPage/index.tsx
@@ -6,10 +6,12 @@ interface AiConversionPageProps {
 
 const AiConversionPage = ({ setStep }: AiConversionPageProps) => {
   return (
-    <div>
+    <div className="h-[61.5rem] w-[50rem] rounded-[1.5rem] border-0 bg-white px-[3rem] shadow-[0_2px_6px_0_rgba(214,214,214,0.25)]">
       <h1>AI Conversion Page</h1>
-      <button onClick={() => setStep(STEP.INFO_INPUT)}>Go to Info Input</button>
-      <button onClick={() => setStep(STEP.CAMERA)}>Go to Camera</button>
+      <div className="inline-flex flex-col">
+        <button onClick={() => setStep(STEP.INFO_INPUT)}>Go to Info Input(다음으로)</button>
+        <button onClick={() => setStep(STEP.CAMERA)}>Go to Camera(이전으로)</button>
+      </div>
     </div>
   );
 };

--- a/src/pageContainer/AiConversionPage/index.tsx
+++ b/src/pageContainer/AiConversionPage/index.tsx
@@ -1,5 +1,17 @@
-const AiConversionPage = () => {
-  return <div>AI Conversion Page</div>;
+import { STEP, type Step } from '../../types';
+
+interface AiConversionPageProps {
+  setStep: React.Dispatch<React.SetStateAction<Step>>;
+}
+
+const AiConversionPage = ({ setStep }: AiConversionPageProps) => {
+  return (
+    <div>
+      <h1>AI Conversion Page</h1>
+      <button onClick={() => setStep(STEP.INFO_INPUT)}>Go to Info Input</button>
+      <button onClick={() => setStep(STEP.CAMERA)}>Go to Camera</button>
+    </div>
+  );
 };
 
 export default AiConversionPage;

--- a/src/pageContainer/AiConversionPage/index.tsx
+++ b/src/pageContainer/AiConversionPage/index.tsx
@@ -6,7 +6,7 @@ interface AiConversionPageProps {
 
 const AiConversionPage = ({ setStep }: AiConversionPageProps) => {
   return (
-    <div className="h-[61.5rem] w-[50rem] rounded-[1.5rem] border-0 bg-white px-[3rem] shadow-[0_2px_6px_0_rgba(214,214,214,0.25)]">
+    <div className="h-[61.5rem] w-[50rem] rounded-[1.5rem] border-0 bg-white px-[3rem] py-[5rem] shadow-[0_2px_6px_0_rgba(214,214,214,0.25)]">
       <h1>AI Conversion Page</h1>
       <div className="inline-flex flex-col">
         <button onClick={() => setStep(STEP.INFO_INPUT)}>Go to Info Input(다음으로)</button>

--- a/src/pageContainer/AiConversionPage/index.tsx
+++ b/src/pageContainer/AiConversionPage/index.tsx
@@ -1,0 +1,5 @@
+const AiConversionPage = () => {
+  return <div>AI Conversion Page</div>;
+};
+
+export default AiConversionPage;

--- a/src/pageContainer/CameraPage/index.tsx
+++ b/src/pageContainer/CameraPage/index.tsx
@@ -6,7 +6,7 @@ interface CameraPageProps {
 
 const CameraPage = ({ setStep }: CameraPageProps) => {
   return (
-    <div className="h-[61.5rem] w-[50rem] rounded-[1.5rem] border-0 bg-white px-[3rem] shadow-[0_2px_6px_0_rgba(214,214,214,0.25)]">
+    <div className="h-[61.5rem] w-[50rem] rounded-[1.5rem] border-0 bg-white px-[3rem] py-[5rem] shadow-[0_2px_6px_0_rgba(214,214,214,0.25)]">
       <h1>Camera Page</h1>
       <div className="inline-flex flex-col">
         <button onClick={() => setStep(STEP.AI_CONVERSION)}>Go to AI Conversion(다음으로)</button>

--- a/src/pageContainer/CameraPage/index.tsx
+++ b/src/pageContainer/CameraPage/index.tsx
@@ -6,9 +6,11 @@ interface CameraPageProps {
 
 const CameraPage = ({ setStep }: CameraPageProps) => {
   return (
-    <div>
+    <div className="h-[61.5rem] w-[50rem] rounded-[1.5rem] border-0 bg-white px-[3rem] shadow-[0_2px_6px_0_rgba(214,214,214,0.25)]">
       <h1>Camera Page</h1>
-      <button onClick={() => setStep(STEP.AI_CONVERSION)}>Go to AI Conversion</button>
+      <div className="inline-flex flex-col">
+        <button onClick={() => setStep(STEP.AI_CONVERSION)}>Go to AI Conversion(다음으로)</button>
+      </div>
     </div>
   );
 };

--- a/src/pageContainer/CameraPage/index.tsx
+++ b/src/pageContainer/CameraPage/index.tsx
@@ -1,0 +1,5 @@
+const CameraPage = () => {
+  return <div>Camera Page</div>;
+};
+
+export default CameraPage;

--- a/src/pageContainer/CameraPage/index.tsx
+++ b/src/pageContainer/CameraPage/index.tsx
@@ -1,5 +1,16 @@
-const CameraPage = () => {
-  return <div>Camera Page</div>;
+import { STEP, type Step } from '../../types';
+
+interface CameraPageProps {
+  setStep: React.Dispatch<React.SetStateAction<Step>>;
+}
+
+const CameraPage = ({ setStep }: CameraPageProps) => {
+  return (
+    <div>
+      <h1>Camera Page</h1>
+      <button onClick={() => setStep(STEP.AI_CONVERSION)}>Go to AI Conversion</button>
+    </div>
+  );
 };
 
 export default CameraPage;

--- a/src/pageContainer/InfoInputPage/index.tsx
+++ b/src/pageContainer/InfoInputPage/index.tsx
@@ -1,0 +1,5 @@
+const InfoInputPage = () => {
+  return <div>Info Input Page</div>;
+};
+
+export default InfoInputPage;

--- a/src/pageContainer/InfoInputPage/index.tsx
+++ b/src/pageContainer/InfoInputPage/index.tsx
@@ -1,5 +1,17 @@
-const InfoInputPage = () => {
-  return <div>Info Input Page</div>;
+import { STEP, type Step } from '../../types';
+
+interface InfoInputPageProps {
+  setStep: React.Dispatch<React.SetStateAction<Step>>;
+}
+
+const InfoInputPage = ({ setStep }: InfoInputPageProps) => {
+  return (
+    <div>
+      <h1>Info Input Page</h1>
+      <button onClick={() => setStep(STEP.THEME_SELECT)}>Go to Theme Select</button>
+      <button onClick={() => setStep(STEP.AI_CONVERSION)}>Go to AI Conversion</button>
+    </div>
+  );
 };
 
 export default InfoInputPage;

--- a/src/pageContainer/InfoInputPage/index.tsx
+++ b/src/pageContainer/InfoInputPage/index.tsx
@@ -6,7 +6,7 @@ interface InfoInputPageProps {
 
 const InfoInputPage = ({ setStep }: InfoInputPageProps) => {
   return (
-    <div className="h-[61.5rem] w-[50rem] rounded-[1.5rem] border-0 bg-white px-[3rem] shadow-[0_2px_6px_0_rgba(214,214,214,0.25)]">
+    <div className="h-[61.5rem] w-[50rem] rounded-[1.5rem] border-0 bg-white px-[3rem] py-[5rem] shadow-[0_2px_6px_0_rgba(214,214,214,0.25)]">
       <h1>Info Input Page</h1>
       <div className="inline-flex flex-col">
         <button onClick={() => setStep(STEP.THEME_SELECT)}>Go to Theme Select(다음으로)</button>

--- a/src/pageContainer/InfoInputPage/index.tsx
+++ b/src/pageContainer/InfoInputPage/index.tsx
@@ -6,10 +6,12 @@ interface InfoInputPageProps {
 
 const InfoInputPage = ({ setStep }: InfoInputPageProps) => {
   return (
-    <div>
+    <div className="h-[61.5rem] w-[50rem] rounded-[1.5rem] border-0 bg-white px-[3rem] shadow-[0_2px_6px_0_rgba(214,214,214,0.25)]">
       <h1>Info Input Page</h1>
-      <button onClick={() => setStep(STEP.THEME_SELECT)}>Go to Theme Select</button>
-      <button onClick={() => setStep(STEP.AI_CONVERSION)}>Go to AI Conversion</button>
+      <div className="inline-flex flex-col">
+        <button onClick={() => setStep(STEP.THEME_SELECT)}>Go to Theme Select(다음으로)</button>
+        <button onClick={() => setStep(STEP.AI_CONVERSION)}>Go to AI Conversion(이전으로)</button>
+      </div>
     </div>
   );
 };

--- a/src/pageContainer/StartPage/index.tsx
+++ b/src/pageContainer/StartPage/index.tsx
@@ -1,0 +1,5 @@
+const StartPage = () => {
+  return <div>Start Page</div>;
+};
+
+export default StartPage;

--- a/src/pageContainer/StartPage/index.tsx
+++ b/src/pageContainer/StartPage/index.tsx
@@ -6,7 +6,7 @@ interface StartPageProps {
 
 const StartPage = ({ setStep }: StartPageProps) => {
   return (
-    <div className="h-[61.5rem] w-[50rem] rounded-[1.5rem] border-0 bg-white px-[3rem] shadow-[0_2px_6px_0_rgba(214,214,214,0.25)]">
+    <div className="h-[61.5rem] w-[50rem] rounded-[1.5rem] border-0 bg-white px-[3rem] py-[5rem] shadow-[0_2px_6px_0_rgba(214,214,214,0.25)]">
       <h1>Start Page</h1>
       <div className="inline-flex flex-col">
         <button onClick={() => setStep(STEP.CAMERA)}>Go to Camera(다음으로)</button>

--- a/src/pageContainer/StartPage/index.tsx
+++ b/src/pageContainer/StartPage/index.tsx
@@ -1,5 +1,16 @@
-const StartPage = () => {
-  return <div>Start Page</div>;
+import { STEP, type Step } from '../../types';
+
+interface StartPageProps {
+  setStep: React.Dispatch<React.SetStateAction<Step>>;
+}
+
+const StartPage = ({ setStep }: StartPageProps) => {
+  return (
+    <div>
+      <h1>Start Page</h1>
+      <button onClick={() => setStep(STEP.CAMERA)}>Go to Camera</button>
+    </div>
+  );
 };
 
 export default StartPage;

--- a/src/pageContainer/StartPage/index.tsx
+++ b/src/pageContainer/StartPage/index.tsx
@@ -6,9 +6,11 @@ interface StartPageProps {
 
 const StartPage = ({ setStep }: StartPageProps) => {
   return (
-    <div>
+    <div className="h-[61.5rem] w-[50rem] rounded-[1.5rem] border-0 bg-white px-[3rem] shadow-[0_2px_6px_0_rgba(214,214,214,0.25)]">
       <h1>Start Page</h1>
-      <button onClick={() => setStep(STEP.CAMERA)}>Go to Camera</button>
+      <div className="inline-flex flex-col">
+        <button onClick={() => setStep(STEP.CAMERA)}>Go to Camera(다음으로)</button>
+      </div>
     </div>
   );
 };

--- a/src/pageContainer/ThemeSelectPage/index.tsx
+++ b/src/pageContainer/ThemeSelectPage/index.tsx
@@ -6,7 +6,7 @@ interface ThemeSelectPageProps {
 
 const ThemeSelectPage = ({ setStep }: ThemeSelectPageProps) => {
   return (
-    <div className="h-[61.5rem] w-[50rem] rounded-[1.5rem] border-0 bg-white px-[3rem] shadow-[0_2px_6px_0_rgba(214,214,214,0.25)]">
+    <div className="h-[61.5rem] w-[50rem] rounded-[1.5rem] border-0 bg-white px-[3rem] py-[5rem] shadow-[0_2px_6px_0_rgba(214,214,214,0.25)]">
       <h1>Theme Select Page</h1>
       <div className="inline-flex flex-col">
         <button onClick={() => setStep(STEP.INFO_INPUT)}>Go to Info Input(이전으로)</button>

--- a/src/pageContainer/ThemeSelectPage/index.tsx
+++ b/src/pageContainer/ThemeSelectPage/index.tsx
@@ -6,9 +6,11 @@ interface ThemeSelectPageProps {
 
 const ThemeSelectPage = ({ setStep }: ThemeSelectPageProps) => {
   return (
-    <div>
+    <div className="h-[61.5rem] w-[50rem] rounded-[1.5rem] border-0 bg-white px-[3rem] shadow-[0_2px_6px_0_rgba(214,214,214,0.25)]">
       <h1>Theme Select Page</h1>
-      <button onClick={() => setStep(STEP.INFO_INPUT)}>Go to Info Input</button>
+      <div className="inline-flex flex-col">
+        <button onClick={() => setStep(STEP.INFO_INPUT)}>Go to Info Input(이전으로)</button>
+      </div>
     </div>
   );
 };

--- a/src/pageContainer/ThemeSelectPage/index.tsx
+++ b/src/pageContainer/ThemeSelectPage/index.tsx
@@ -1,0 +1,5 @@
+const ThemeSelectPage = () => {
+  return <div>Theme Select Page</div>;
+};
+
+export default ThemeSelectPage;

--- a/src/pageContainer/ThemeSelectPage/index.tsx
+++ b/src/pageContainer/ThemeSelectPage/index.tsx
@@ -1,5 +1,16 @@
-const ThemeSelectPage = () => {
-  return <div>Theme Select Page</div>;
+import { STEP, type Step } from '../../types';
+
+interface ThemeSelectPageProps {
+  setStep: React.Dispatch<React.SetStateAction<Step>>;
+}
+
+const ThemeSelectPage = ({ setStep }: ThemeSelectPageProps) => {
+  return (
+    <div>
+      <h1>Theme Select Page</h1>
+      <button onClick={() => setStep(STEP.INFO_INPUT)}>Go to Info Input</button>
+    </div>
+  );
 };
 
 export default ThemeSelectPage;

--- a/src/pageContainer/index.ts
+++ b/src/pageContainer/index.ts
@@ -1,0 +1,5 @@
+export { default as AiConversionPage } from './AiConversionPage';
+export { default as CameraPage } from './CameraPage';
+export { default as InfoInputPage } from './InfoInputPage';
+export { default as StartPage } from './StartPage';
+export { default as ThemeSelectPage } from './ThemeSelectPage';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,1 @@
+export * from './step';

--- a/src/types/step.ts
+++ b/src/types/step.ts
@@ -1,0 +1,9 @@
+export const STEP = {
+  START: 'START',
+  CAMERA: 'CAMERA',
+  AI_CONVERSION: 'AI_CONVERSION',
+  INFO_INPUT: 'INFO_INPUT',
+  THEME_SELECT: 'THEME_SELECT',
+} as const;
+
+export type Step = (typeof STEP)[keyof typeof STEP];


### PR DESCRIPTION
## 개요 💡

스텝 이동 기능 구현 및 공통 ui 적용했습니다.

## 작업내용 ⌨️

- 스텝 별 페이지 컨테이너 구현
- 스텝 타입 정의
- 스텝에 따른 렌더링 구현
- 스텝 간 이동 기능 구현
- 스텝 별 공통 ui 적용

## 스크린샷/동영상 📸

https://github.com/user-attachments/assets/8417c905-5017-4d93-ad7c-ce97f90d0cfc

## 관련 이슈 🚨

typescript의 erasableSyntaxOnly 옵션 때문에 enum 대신 as const로 객체를 정의하여 step 타입을 정의했습니다.