### PR TITLE
[style] h1 태그 폰트 두께 수정

### DIFF
--- a/src/pageContainer/StartPage/index.tsx
+++ b/src/pageContainer/StartPage/index.tsx
@@ -20,7 +20,7 @@ const StartPage = ({ setStep, setCardType }: StartPageProps) => {
   return (
     <div className="flex h-[61.5rem] w-[50rem] flex-col gap-[11.25rem] rounded-[1.5rem] border-0 bg-white px-[3rem] py-[5rem] pt-[17.5rem] shadow-[0_2px_6px_0_rgba(214,214,214,0.25)]">
       <div className="flex flex-col gap-4">
-        <h1 className="text-[4rem]/[4rem] font-black text-[#222]">WHO ARE YOU</h1>
+        <h1 className="text-[4rem]/[4rem] font-extrabold text-[#222]">WHO ARE YOU</h1>
         <p className="text-[1.25rem]/[1.75rem] font-medium text-[#666]">
           AI로 변환한 사진으로 인생네컷을 찍거나
           <br />

--- a/src/pageContainer/ThemeSelectPage/index.tsx
+++ b/src/pageContainer/ThemeSelectPage/index.tsx
@@ -111,7 +111,7 @@ const ThemeSelectPage = ({ setStep, cardType }: ThemeSelectPageProps) => {
           isLandscapeBusinessCard ? 'mb-[2.1563rem]' : isFourCut ? 'mb-[3rem]' : 'mb-[6.875rem]'
         } flex flex-col gap-4`}
       >
-        <h1 className="text-[2.25rem]/[2.25rem] font-black text-[#222]">
+        <h1 className="text-[2.25rem]/[2.25rem] font-extrabold text-[#222]">
           {cardTypeLabel} 테마 선택
         </h1>
         <p className="text-[1.25rem]/[1.875rem] font-medium text-[#666]">


### PR DESCRIPTION
## 개요 💡

변경된 디자인대로 h1 태그 폰트 두께 수정했습니다.

## 작업내용 ⌨️

- h1 태그 폰트 두께 수정

## 스크린샷/동영상 📸

### 변경전

<img width="1728" height="1117" alt="스크린샷 2025-10-14 오후 2 09 43" src="https://github.com/user-attachments/assets/baaddcef-9817-480b-b293-314cfb390712" />

### 변경후

<img width="1728" height="1117" alt="스크린샷 2025-10-14 오후 2 09 27" src="https://github.com/user-attachments/assets/c22c5ad1-d2b6-4d64-852c-6a7931980268" />
