### PR TITLE
[fix] InfoInputPage 실시간 검증 UI 개선

### DIFF
--- a/src/components/InputFormItem/index.tsx
+++ b/src/components/InputFormItem/index.tsx
@@ -8,7 +8,10 @@ interface InputFormItemProps extends React.InputHTMLAttributes<HTMLInputElement>
 }
 
 const InputFormItem = forwardRef<HTMLInputElement, InputFormItemProps>(
-  ({ inputTitle, placeholder, errorMessage, required = false, ...rest }, ref) => {
+  (
+    { inputTitle, placeholder, errorMessage, required = false, value, onChange, onBlur, ...rest },
+    ref,
+  ) => {
     return (
       <div className="flex flex-col">
         <label className="mb-[0.75rem] flex items-center px-[0.25rem] text-[#222]">
@@ -26,11 +29,14 @@ const InputFormItem = forwardRef<HTMLInputElement, InputFormItemProps>(
 
         <input
           ref={ref}
+          value={value}
+          onChange={onChange}
+          onBlur={onBlur}
           placeholder={placeholder}
           className={`rounded-[0.75rem] border p-[1rem] text-[1rem]/[1rem] font-medium placeholder-[#888] transition-colors duration-[150ms] ease-[cubic-bezier(0.97,-0.02,0.03,1)] outline-none ${
             errorMessage
               ? 'border-[#FF0002] text-[#222]'
-              : 'border-[#888] text-[#888] hover:border-[#666] hover:text-[#666] hover:placeholder-[#666] focus:border-[#222] focus:bg-[#F8F8F8] focus:text-[#222] focus:placeholder-[#222]'
+              : 'border-[#888] text-[#222] hover:border-[#666] hover:text-[#222] focus:border-[#222] focus:bg-[#F8F8F8] focus:text-[#222]'
           }`}
           {...rest}
         />

--- a/src/pageContainer/InfoInputPage/index.tsx
+++ b/src/pageContainer/InfoInputPage/index.tsx
@@ -1,6 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod';
-import type { SubmitHandler } from 'react-hook-form';
-import { useForm } from 'react-hook-form';
+import { Controller, type SubmitHandler, useForm } from 'react-hook-form';
 
 import { InputFormItem, StepButton } from '../../components';
 import { userInfoFormSchema } from '../../schemas/userInfoFormSchema';
@@ -14,9 +13,9 @@ interface InfoInputPageProps {
 
 const InfoInputPage = ({ userInfo, setUserInfo, setStep }: InfoInputPageProps) => {
   const {
-    register,
+    control,
     handleSubmit,
-    formState: { errors, isValid },
+    formState: { isValid },
   } = useForm<userInfoFormType>({
     resolver: zodResolver(userInfoFormSchema),
     defaultValues: {
@@ -65,13 +64,22 @@ const InfoInputPage = ({ userInfo, setUserInfo, setStep }: InfoInputPageProps) =
 
       <div className="mt-12 flex flex-col gap-[2.25rem]">
         {inputFields.map((field) => (
-          <InputFormItem
+          <Controller
             key={field.name}
-            {...register(field.name)}
-            inputTitle={field.title}
-            placeholder={field.placeholder}
-            errorMessage={errors[field.name]?.message}
-            required={field.required}
+            name={field.name}
+            control={control}
+            render={({ field: { value, onChange, onBlur, ref }, fieldState: { error } }) => (
+              <InputFormItem
+                inputTitle={field.title}
+                placeholder={field.placeholder}
+                required={field.required}
+                value={value}
+                onChange={onChange}
+                onBlur={onBlur}
+                ref={ref}
+                errorMessage={error?.message}
+              />
+            )}
           />
         ))}
       </div>


### PR DESCRIPTION
## 개요 💡

> `InfoInputPage`에서 입력값 변경 시 에러 메시지와 red border가 즉시 반영되지 않던 문제를 해결했습니다.

## 작업내용 ⌨️
1. **InputFormItem**
   * uncontrolled input → controlled input으로 변경
   * `value`, `onChange`, `onBlur`를 명시적으로 받아 사용
2. **InfoInputPage**
   * `useForm`의 `register` → `Controller`로 변경
   * 각 `InputFormItem`에 `Controller`를 통해 `value`, `onChange`, `onBlur`, `ref` 전달
   * `mode: 'onChange'` 적용으로 입력 시 실시간 유효성 검증 가능

## 변경 이유
* 기존 코드에서는 `register` 사용으로 인해:
  * 입력 시 에러 메시지와 border 상태가 즉시 반영되지 않음
  * 값 변경 후에도 이전 에러 메시지가 남아 있음